### PR TITLE
registry user is more generic

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,7 +2,7 @@ image: $HELM_REGISTRY_IMAGE:$HELM_REGISTRY_VERSION
 
 variables:
   REGISTRY: quay.io
-  REGISTRY_USER: samsung_cnct
+  REGISTRY_USER: your_org # we set this to override to samsung_cnct in gitlab Group Variables
   CHART_NAME: zabra
   ROBOT_ACCOUNT: zabra_rw
   HELM_REGISTRY_IMAGE: quay.io/samsung_cnct/helm-registry-agent


### PR DESCRIPTION
We can set the REGISTRY_USER as a group variable to the value `samsung_cnct`. This will automatically apply the variable to all projects in the group. Third party users can either insert their org name in the file, or settheir own group vars.
No extra setup is needed, although we should make a note in solas that this is being done.